### PR TITLE
Add method for logging in a user with a test request

### DIFF
--- a/pkg/seshttp/middleware.go
+++ b/pkg/seshttp/middleware.go
@@ -72,15 +72,14 @@ func NewSessionCookieService(secure bool) SessionCookieService {
 	}
 }
 
-// AddSessionKeyToResponse adds the session cookie to a response given a valid sessionKey
-func (s SessionCookieService) AddSessionKeyToResponse(w http.ResponseWriter, sessionKey string) {
+func sessionCookie(sessionKey string, secure bool) *http.Cookie {
 	// LESSONS:
 	// The domain must be "" for localhost to work
 	// Safari will fuck up cookies if you have a .local hostname, chrome does fine
 	// Secure must be false for http to work
 
-	cookie := &http.Cookie{
-		Secure:   s.secure,
+	return &http.Cookie{
+		Secure:   secure,
 		Name:     SessionCookieName,
 		Value:    sessionKey,
 		HttpOnly: true,
@@ -88,13 +87,27 @@ func (s SessionCookieService) AddSessionKeyToResponse(w http.ResponseWriter, ses
 		// Omit MaxAge and Expires to make this a session cookie.
 		// Omit domain to default to the full domain
 	}
+}
+
+// AddSessionKeyToResponse adds the session cookie to a response given a valid sessionKey
+func (s SessionCookieService) AddSessionKeyToResponse(w http.ResponseWriter, sessionKey string) {
+
+	cookie := sessionCookie(sessionKey, s.secure)
 
 	http.SetCookie(w, cookie)
+}
 
+// AddSessionKeyToRequest adds the session cookie to a request given a valid sessionKey
+func (s SessionCookieService) AddSessionKeyToRequest(r *http.Request, sessionKey string) {
+
+	cookie := sessionCookie(sessionKey, s.secure)
+
+	r.AddCookie(cookie)
 }
 
 // DeleteSessionCookie removes the session cookie
 func DeleteSessionCookie(w http.ResponseWriter) {
+	fmt.Println("DELETING COOK!")
 	cookie := &http.Cookie{
 		Name:   SessionCookieName,
 		MaxAge: -1,

--- a/sesh.go
+++ b/sesh.go
@@ -91,15 +91,3 @@ func SessionFromContext(ctx context.Context) Session {
 	}
 	return session
 }
-
-// ContextWithTestSession is not used in the operation of sesh. It is intended to
-// be used in your tests, to mimic what AuthenticatedMiddleware does for authenticated requests.
-func ContextWithTestSession(ctx context.Context, session Session) context.Context {
-	domainSession := domain.Session{
-		AccountID:      session.AccountID,
-		SessionKey:     session.SessionKey,
-		ExpirationDate: session.ExpirationDate,
-	}
-
-	return seshttp.SetSessionInContext(ctx, domainSession)
-}

--- a/testing.go
+++ b/testing.go
@@ -1,0 +1,37 @@
+package sesh
+
+// Everything exported in this file is intended to be used to make testing code that is protected by sesh easier.
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/trussworks/sesh/pkg/domain"
+	"github.com/trussworks/sesh/pkg/seshttp"
+)
+
+// ContextWithTestSession is not used in the operation of sesh. It is intended to
+// be used in your tests, to mimic what AuthenticatedMiddleware does for authenticated requests.
+func ContextWithTestSession(ctx context.Context, session Session) context.Context {
+	domainSession := domain.Session{
+		AccountID:      session.AccountID,
+		SessionKey:     session.SessionKey,
+		ExpirationDate: session.ExpirationDate,
+	}
+
+	return seshttp.SetSessionInContext(ctx, domainSession)
+}
+
+// AuthenticateUserAndAddToTestRequest is not used in the operation of sesh. It is intended to
+// be used in your tests to create a valid session for a request, alleviating you from having to make a login request
+// as part of the test.
+func (s Sessions) AuthenticateUserAndAddToTestRequest(r *http.Request, accountID string) error {
+	sessionKey, authErr := s.session.UserDidAuthenticate(accountID)
+	if authErr != nil {
+		return authErr
+	}
+
+	s.cookie.AddSessionKeyToRequest(r, sessionKey)
+
+	return nil
+}


### PR DESCRIPTION
This commit adds another test helper method. 

AuthenticateUserAndAddToTestRequest will run the authentication code and add the correct session cookie that the middleware expects to the given request. This is useful if you are testing with the middleware in place and don't want to make a login request to create a session. 