### PR TITLE
Ensure cookie gets deleted when user logs out

### DIFF
--- a/pkg/seshttp/middleware.go
+++ b/pkg/seshttp/middleware.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/trussworks/sesh/pkg/domain"
 )
@@ -84,6 +85,7 @@ func sessionCookie(sessionKey string, secure bool) *http.Cookie {
 		Value:    sessionKey,
 		HttpOnly: true,
 		Path:     "/",
+		SameSite: http.SameSiteLaxMode,
 		// Omit MaxAge and Expires to make this a session cookie.
 		// Omit domain to default to the full domain
 	}
@@ -107,10 +109,13 @@ func (s SessionCookieService) AddSessionKeyToRequest(r *http.Request, sessionKey
 
 // DeleteSessionCookie removes the session cookie
 func DeleteSessionCookie(w http.ResponseWriter) {
-	fmt.Println("DELETING COOK!")
 	cookie := &http.Cookie{
 		Name:   SessionCookieName,
+		Value: "",
+		Path: "/",
 		MaxAge: -1,
+		Expires: time.Unix(1, 0),
+		HttpOnly: true,
 	}
 	http.SetCookie(w, cookie)
 }


### PR DESCRIPTION
For some reason, when testing this with the `mymove` repo, the
cookie wasn't being deleted. Adding these additional cookie settings
allowed the cookie to be deleted.

Looking at how other Golang session management packages delete cookies,
it seems to be a standard thing to have all of these cookie attributes
in place. To delete the cookie, the `Value` is set to an empty
string, `MaxAge` to `-1`, and `Expires` to `time.Unix(1, 0)`.